### PR TITLE
Complete backend skeleton

### DIFF
--- a/CODE/api/dependencies.py
+++ b/CODE/api/dependencies.py
@@ -1,0 +1,10 @@
+from fastapi import Header, HTTPException, Depends
+from django.db.models import Q
+from apps.applications.models import APIKey
+
+async def get_application(x_api_key: str = Header(...)):
+    try:
+        api_key = APIKey.objects.select_related('application').get(Q(key=x_api_key), is_active=True, application__is_active=True)
+    except APIKey.DoesNotExist:
+        raise HTTPException(status_code=403, detail='Invalid API Key')
+    return api_key.application

--- a/CODE/api/routes/auth.py
+++ b/CODE/api/routes/auth.py
@@ -1,9 +1,8 @@
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Depends
+from api.dependencies import get_application
 
 router = APIRouter()
 
 @router.get("/verify")
-def verify_token(x_api_key: str = Header(...)):
-    if not x_api_key or len(x_api_key) < 32:
-        raise HTTPException(status_code=403, detail="Invalid API Key")
-    return {"status": "valid"}
+def verify_token(app=Depends(get_application)):
+    return {"status": "valid", "application": app.name}

--- a/CODE/api/routes/email_send.py
+++ b/CODE/api/routes/email_send.py
@@ -1,5 +1,8 @@
-from fastapi import APIRouter, HTTPException, Header, status
+from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, EmailStr
+from api.dependencies import get_application
+from apps.emails.models import EmailLog
+from apps.emails.tasks import send_email_task
 import uuid
 
 router = APIRouter()
@@ -10,9 +13,17 @@ class EmailSendRequest(BaseModel):
     subject: str
     body: str
 
-@router.post("/send")
-def send_email(request: EmailSendRequest, x_api_key: str = Header(...)):
-    if not x_api_key:
-        raise HTTPException(status_code=403, detail="Missing API Key")
-    message_id = str(uuid.uuid4())
-    return {"message_id": message_id, "status": "queued"}
+
+@router.post("/send", status_code=status.HTTP_202_ACCEPTED)
+def send_email(request: EmailSendRequest, app=Depends(get_application)):
+    log = EmailLog.objects.create(
+        application=app,
+        message_id=str(uuid.uuid4()),
+        sender=request.from_email,
+        recipient=request.to_email,
+        subject=request.subject,
+        body=request.body,
+        direction='outbound',
+    )
+    send_email_task.delay(log.id)
+    return {"message_id": log.message_id, "status": "queued"}

--- a/CODE/api/routes/webhook_receive.py
+++ b/CODE/api/routes/webhook_receive.py
@@ -1,12 +1,23 @@
-from fastapi import APIRouter, Request, Header, HTTPException
+from fastapi import APIRouter, Request, Depends
 import uuid
+from api.dependencies import get_application
+from apps.emails.models import EmailLog
+from apps.emails.tasks import forward_inbound_email
 
 router = APIRouter()
 
 @router.post("/")
-async def receive_inbound_email(request: Request, x_api_key: str = Header(...)):
-    if not x_api_key:
-        raise HTTPException(status_code=403, detail="Missing API Key")
+async def receive_inbound_email(request: Request, app=Depends(get_application)):
     data = await request.json()
-    message_id = str(uuid.uuid4())
-    return {"message_id": message_id, "status": "received", "content": data}
+    log = EmailLog.objects.create(
+        application=app,
+        message_id=str(uuid.uuid4()),
+        sender=data.get('from'),
+        recipient=data.get('to'),
+        subject=data.get('subject', ''),
+        body=data.get('body', ''),
+        direction='inbound',
+        status='received'
+    )
+    forward_inbound_email.delay(log.id)
+    return {"message_id": log.message_id, "status": "received"}

--- a/CODE/apps/applications/migrations/0001_initial.py
+++ b/CODE/apps/applications/migrations/0001_initial.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='Application',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=100, unique=True)),
+                ('description', models.TextField(blank=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('is_active', models.BooleanField(default=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='APIKey',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('key', models.CharField(editable=False, max_length=64, unique=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('is_active', models.BooleanField(default=True)),
+                ('application', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='api_keys', to='applications.application')),
+            ],
+        ),
+    ]

--- a/CODE/apps/applications/models.py
+++ b/CODE/apps/applications/models.py
@@ -1,0 +1,25 @@
+from django.db import models
+import secrets
+
+class Application(models.Model):
+    name = models.CharField(max_length=100, unique=True)
+    description = models.TextField(blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    is_active = models.BooleanField(default=True)
+
+    def __str__(self):
+        return self.name
+
+class APIKey(models.Model):
+    application = models.ForeignKey(Application, on_delete=models.CASCADE, related_name='api_keys')
+    key = models.CharField(max_length=64, unique=True, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    is_active = models.BooleanField(default=True)
+
+    def save(self, *args, **kwargs):
+        if not self.key:
+            self.key = secrets.token_hex(32)
+        return super().save(*args, **kwargs)
+
+    def __str__(self):
+        return f"{self.application.name} - {self.key[:8]}"

--- a/CODE/apps/domains/migrations/0001_initial.py
+++ b/CODE/apps/domains/migrations/0001_initial.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        ('applications', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Domain',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('domain_name', models.CharField(max_length=255, unique=True)),
+                ('is_verified', models.BooleanField(default=False)),
+                ('verification_token', models.CharField(max_length=64, unique=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('application', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='domains', to='applications.application')),
+            ],
+        ),
+    ]

--- a/CODE/apps/emails/migrations/0001_initial.py
+++ b/CODE/apps/emails/migrations/0001_initial.py
@@ -1,0 +1,28 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        ('applications', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='EmailLog',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('message_id', models.CharField(max_length=255, unique=True)),
+                ('sender', models.EmailField(max_length=254)),
+                ('recipient', models.EmailField(max_length=254)),
+                ('subject', models.CharField(max_length=512)),
+                ('body', models.TextField()),
+                ('direction', models.CharField(choices=[('inbound', 'Inbound'), ('outbound', 'Outbound')], max_length=10)),
+                ('status', models.CharField(default='queued', max_length=50)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('application', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='emails', to='applications.application')),
+            ],
+        ),
+    ]

--- a/CODE/apps/emails/tasks.py
+++ b/CODE/apps/emails/tasks.py
@@ -1,0 +1,44 @@
+from celery import shared_task
+from django.conf import settings
+from .models import EmailLog
+import boto3
+import requests
+
+@shared_task
+def send_email_task(email_log_id):
+    email_log = EmailLog.objects.get(id=email_log_id)
+    ses = boto3.client(
+        'ses',
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        region_name=settings.AWS_REGION,
+    )
+    try:
+        ses.send_email(
+            Source=email_log.sender,
+            Destination={'ToAddresses': [email_log.recipient]},
+            Message={
+                'Subject': {'Data': email_log.subject},
+                'Body': {'Text': {'Data': email_log.body}},
+            },
+        )
+        email_log.status = 'sent'
+    except Exception as e:
+        email_log.status = f'error: {e}'
+    email_log.save()
+    return email_log.message_id
+
+@shared_task
+def forward_inbound_email(email_log_id):
+    email_log = EmailLog.objects.get(id=email_log_id)
+    url = email_log.application.webhook.endpoint_url
+    try:
+        requests.post(url, json={
+            'message_id': email_log.message_id,
+            'sender': email_log.sender,
+            'recipient': email_log.recipient,
+            'subject': email_log.subject,
+            'body': email_log.body,
+        }, timeout=10)
+    except Exception:
+        pass

--- a/CODE/apps/webhooks/migrations/0001_initial.py
+++ b/CODE/apps/webhooks/migrations/0001_initial.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        ('applications', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Webhook',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('endpoint_url', models.URLField()),
+                ('is_active', models.BooleanField(default=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('application', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='webhook', to='applications.application')),
+            ],
+        ),
+    ]

--- a/CODE/core/celery.py
+++ b/CODE/core/celery.py
@@ -1,0 +1,9 @@
+import os
+from celery import Celery
+from django.conf import settings
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
+
+app = Celery('core')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/CODE/core/settings.py
+++ b/CODE/core/settings.py
@@ -91,3 +91,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 CELERY_BROKER_URL = REDIS_URL
 CELERY_RESULT_BACKEND = REDIS_URL
+
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "")
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Third-Party Email Integration Server
+
+This project provides a simple backend combining **Django** and **FastAPI** to send and receive emails on behalf of third‑party applications. Emails are delivered via Amazon SES and inbound messages are forwarded to application defined webhooks.
+
+## Features
+- Registration of applications and API keys via Django admin
+- Domain and webhook management
+- REST API for sending emails (`/api/email/send`)
+- Webhook endpoint for receiving inbound emails (`/api/webhook/`)
+- Asynchronous processing using Celery and Redis
+
+## Setup
+1. Install dependencies
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Configure environment variables (e.g. in a `.env` file):
+   ```
+   SECRET_KEY=changeme
+   POSTGRES_DB=email_service
+   POSTGRES_USER=user
+   POSTGRES_PASSWORD=password
+   POSTGRES_HOST=localhost
+   AWS_ACCESS_KEY_ID=your_key
+   AWS_SECRET_ACCESS_KEY=your_secret
+   AWS_REGION=us-east-1
+   REDIS_URL=redis://localhost:6379/0
+   ```
+3. Run migrations and create a superuser
+   ```bash
+   ./manage.py migrate
+   ./manage.py createsuperuser
+   ```
+4. Start the development server
+   ```bash
+   uvicorn core.asgi:app --reload
+   ```
+5. Start Celery worker in another terminal
+   ```bash
+   celery -A core worker -l info
+   ```
+
+## Usage
+- Obtain an API key from the Django admin.
+- Send emails by POSTing to `/api/email/send` with your API key in the `X-API-Key` header.
+- Configure your email provider to POST inbound messages to `/api/webhook/` with the same header.
+
+This repository provides a minimal but functional foundation which can be extended with additional features such as domain verification and analytics.

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+Django>=3.2
+fastapi
+uvicorn
+boto3
+celery
+redis
+requests
+python-dotenv
+psycopg2-binary


### PR DESCRIPTION
## Summary
- add Django manage.py
- create Application and APIKey models
- implement Celery tasks for sending and forwarding email
- secure API routes with key authentication
- document setup in README

## Testing
- `python manage.py makemigrations apps.applications apps.domains apps.emails apps.webhooks` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_685db56902e88329bb104d83c7c6f14b